### PR TITLE
Adding ability to add a new status when the system is logged out (log…

### DIFF
--- a/.idea/modules/SlackUserPresenceManager.iml
+++ b/.idea/modules/SlackUserPresenceManager.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="SlackUserPresenceManager" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.SlackUserPresenceManager" external.system.module.version="1.1-" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="SlackUserPresenceManager" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.SlackUserPresenceManager" external.system.module.version="1.2-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">

--- a/.idea/modules/SlackUserPresenceManager_main.iml
+++ b/.idea/modules/SlackUserPresenceManager_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="SlackUserPresenceManager:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.SlackUserPresenceManager" external.system.module.type="sourceSet" external.system.module.version="1.1-" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="SlackUserPresenceManager:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.SlackUserPresenceManager" external.system.module.type="sourceSet" external.system.module.version="1.2-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/../../build/classes/main" />
     <exclude-output />

--- a/.idea/modules/SlackUserPresenceManager_test.iml
+++ b/.idea/modules/SlackUserPresenceManager_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="SlackUserPresenceManager:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.SlackUserPresenceManager" external.system.module.type="sourceSet" external.system.module.version="1.1-" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="SlackUserPresenceManager:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="com.SlackUserPresenceManager" external.system.module.type="sourceSet" external.system.module.version="1.2-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
     <exclude-output />

--- a/SlackUserPresenceManager.properties
+++ b/SlackUserPresenceManager.properties
@@ -3,3 +3,5 @@ active-message=
 active-emoji=
 away-message=AFK
 away-emoji=mountain_railway
+logged-off-message=
+logged-off-emoji=

--- a/src/main/java/com/slackuserpresencemanager/HTTPManager.java
+++ b/src/main/java/com/slackuserpresencemanager/HTTPManager.java
@@ -1,6 +1,7 @@
 package com.slackuserpresencemanager;
 
 import com.google.gson.Gson;
+import com.slackuserpresencemanager.slack.Presence;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -15,7 +16,7 @@ import java.util.Map;
  * Created by Tharaka on 6/12/2017.
  * For project: SlackUserPresenceManager
  */
-class HTTPManager {
+public class HTTPManager {
 
     private final static Logger LOGGER = LogManager.getLogger(HTTPManager.class);
 
@@ -41,14 +42,14 @@ class HTTPManager {
         }
     }
 
-    static void updateStatus(final String message, final String emoji) {
+    public static void updateStatus(final String message, final String emoji) {
         Map<String, String> statusInfo = new HashMap<>();
         statusInfo.put("status_text", message);
         statusInfo.put("status_emoji", ":".concat(emoji).concat(":"));
         update(RESOURCE_STATUS, "profile", new Gson().toJson(statusInfo));
     }
 
-    static void updatePresence(final String presence) {
-        update(RESOURCE_PRESENCE, "presence", presence);
+    public static void updatePresence(final Presence presence) {
+        update(RESOURCE_PRESENCE, "presence", presence.getPresenceString());
     }
 }

--- a/src/main/java/com/slackuserpresencemanager/Main.java
+++ b/src/main/java/com/slackuserpresencemanager/Main.java
@@ -29,7 +29,7 @@ public class Main {
         }
         FileInputStream inputStream = new FileInputStream(file);
         properties.load(inputStream);
-        WindowsStateManager.RegisterShutdownListener();
+        WindowsStateManager.registerShutdownListener();
         new WindowsSessionManager();
     }
 }

--- a/src/main/java/com/slackuserpresencemanager/Main.java
+++ b/src/main/java/com/slackuserpresencemanager/Main.java
@@ -29,6 +29,7 @@ public class Main {
         }
         FileInputStream inputStream = new FileInputStream(file);
         properties.load(inputStream);
+        WindowsStateManager.RegisterShutdownListener();
         new WindowsSessionManager();
     }
 }

--- a/src/main/java/com/slackuserpresencemanager/WindowsSessionManager.java
+++ b/src/main/java/com/slackuserpresencemanager/WindowsSessionManager.java
@@ -1,5 +1,6 @@
 package com.slackuserpresencemanager;
 
+import com.slackuserpresencemanager.slack.Presence;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.User32;
 import com.sun.jna.platform.win32.WinDef.*;
@@ -20,7 +21,7 @@ public class WindowsSessionManager implements WindowProc {
 
     WindowsSessionManager() {
         HTTPManager.updateStatus(Main.getProperty("active-message"), Main.getProperty("active-emoji"));
-        HTTPManager.updatePresence("auto");
+        HTTPManager.updatePresence(Presence.AUTO);
 
         // define new window class
         String windowClass = "MyWindowClass";
@@ -116,11 +117,11 @@ public class WindowsSessionManager implements WindowProc {
 
     private void onMachineLocked() {
         HTTPManager.updateStatus(Main.getProperty("away-message"), Main.getProperty("away-emoji"));
-        HTTPManager.updatePresence("away");
+        HTTPManager.updatePresence(Presence.AWAY);
     }
 
     private void onMachineUnlocked() {
         HTTPManager.updateStatus(Main.getProperty("active-message"), Main.getProperty("active-emoji"));
-        HTTPManager.updatePresence("auto");
+        HTTPManager.updatePresence(Presence.AUTO);
     }
 }

--- a/src/main/java/com/slackuserpresencemanager/WindowsStateManager.java
+++ b/src/main/java/com/slackuserpresencemanager/WindowsStateManager.java
@@ -7,7 +7,7 @@ import com.slackuserpresencemanager.slack.Presence;
  * Project: SlackUserPresenceManager
  */
 class WindowsStateManager {
-    static void RegisterShutdownListener() {
+    static void registerShutdownListener() {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             HTTPManager.updatePresence(Presence.AWAY);
             HTTPManager.updateStatus(Main.getProperty("logged-off-message"), Main.getProperty("logged-off-emoji"));

--- a/src/main/java/com/slackuserpresencemanager/WindowsStateManager.java
+++ b/src/main/java/com/slackuserpresencemanager/WindowsStateManager.java
@@ -1,0 +1,16 @@
+package com.slackuserpresencemanager;
+
+import com.slackuserpresencemanager.slack.Presence;
+
+/**
+ * Created by Christian on 6/14/2017.
+ * Project: SlackUserPresenceManager
+ */
+class WindowsStateManager {
+    static void RegisterShutdownListener() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            HTTPManager.updatePresence(Presence.AWAY);
+            HTTPManager.updateStatus(Main.getProperty("logged-off-message"), Main.getProperty("logged-off-emoji"));
+        }));
+    }
+}

--- a/src/main/java/com/slackuserpresencemanager/slack/Presence.java
+++ b/src/main/java/com/slackuserpresencemanager/slack/Presence.java
@@ -1,0 +1,20 @@
+package com.slackuserpresencemanager.slack;
+
+/**
+ * Created by Christian on 6/14/2017.
+ * Project: SlackUserPresenceManager
+ */
+public enum Presence {
+    AUTO("auto"),
+    AWAY("away");
+
+    private String slackString;
+
+    Presence(final String slackString) {
+        this.slackString = slackString;
+    }
+
+    public String getPresenceString() {
+        return this.slackString;
+    }
+}


### PR DESCRIPTION
- Adding ability to add a new status when the system is logged out (logged out, not locked, this includes shutdown)
-Tested and working currently (only for logout, needs to be a service to be able to handle start up and shut down both)
- This does not contain code to make this a service, this is something that I'm working on and will update soon with another PR. In the meantime I added myself as the assignee to https://github.com/tharakadesilva/SlackUserPresenceManager/issues/5